### PR TITLE
gallery: replace deprecated DOMNode events

### DIFF
--- a/src/components/Gallery.svelte
+++ b/src/components/Gallery.svelte
@@ -28,7 +28,14 @@
     }
   }
 
-  onMount(draw);
+  onMount(() => {
+    draw();
+
+    const observer = new MutationObserver(draw);
+    observer.observe(slotHolder, { childList: true });
+
+    return () => observer.disconnect();
+  });
 </script>
 
 <style>
@@ -71,8 +78,6 @@
 <div
   class="slot-holder"
   bind:this={slotHolder}
-  on:DOMNodeInserted={draw}
-  on:DOMNodeRemoved={draw}
 >
   <slot />
 </div>


### PR DESCRIPTION
This fixes `/album`  page on modern Chrome versions since the DOMNode events are not supported anymore.
Backport of gambiconf/2023#1 to 2022.